### PR TITLE
feat: add text annotation layer

### DIFF
--- a/Gotho.BlazorPdf.MudBlazor/Config/MudPdfIconConfig.cs
+++ b/Gotho.BlazorPdf.MudBlazor/Config/MudPdfIconConfig.cs
@@ -20,4 +20,6 @@ public class MudPdfIconConfig
     public string Error { get; set; } = global::MudBlazor.Icons.Material.Filled.Error;
     public string Draw { get; set; } = global::MudBlazor.Icons.Material.Filled.Draw;
     public string DrawClose { get; set; } = global::MudBlazor.Icons.Material.Filled.Close;
+    public string Text { get; set; } = global::MudBlazor.Icons.Material.Filled.Title;
+    public string TextClose { get; set; } = global::MudBlazor.Icons.Material.Filled.Close;
 }

--- a/Gotho.BlazorPdf.MudBlazor/MudPdfViewer.razor
+++ b/Gotho.BlazorPdf.MudBlazor/MudPdfViewer.razor
@@ -88,6 +88,8 @@
                 <MudDivider/>
                 <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.Draw" Label="@LocalizedStrings.Draw"
                              OnClick="ToggleDrawingAsync"/>
+                <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.Text" Label="@LocalizedStrings.Text"
+                             OnClick="ToggleTextAsync"/>
             </MudMenu>
         </MudToolBar>
         @if (Loading)
@@ -167,6 +169,26 @@
                         </MudCardActions>
                     </MudCard>
                 }
+                @if (PdfFile.TextLayer.Enabled)
+                {
+                    <MudCard Class="mudpdf_drawcard">
+                        <MudCardHeader Class="justify-space-between">
+                            <MudText Align="Align.Center">@LocalizedStrings.TextTools</MudText>
+                            <MudIconButton Icon="@Icons.TextClose" Color="Color.Default" OnClick="ToggleTextAsync"/>
+                        </MudCardHeader>
+                        <MudCardActions Class="justify-center">
+                            <MudStack>
+                                <MudColorPicker Label="@LocalizedStrings.TextColor" ShowAlpha="false"
+                                                Value="@PdfFile.TextLayer.TextColor" ValueChanged="TextColorChanged"/>
+                                <MudTextField Label="@LocalizedStrings.TextFont" Value="@PdfFile.TextLayer.Font" ValueChanged="FontChanged"/>
+                            </MudStack>
+                        </MudCardActions>
+                        <MudCardActions Class="justify-center">
+                            <MudButton OnClick="UndoLastTextAsync">@LocalizedStrings.TextUndo</MudButton>
+                            <MudButton OnClick="ClearAllPageTextAsync">@LocalizedStrings.TextClear</MudButton>
+                        </MudCardActions>
+                    </MudCard>
+                }
             </div>
 
             <div class="@(Error is not null ? "blazorpdf-d-none" : "")" style="margin: auto">
@@ -188,6 +210,10 @@
                         <div>
                             @* Drawing Layer *@
                             <canvas id="@($"{PdfFile.Id}_drawing")" class="blazorpdf-drawing__canvas"></canvas>
+                        </div>
+                        <div>
+                            @* Text Annotation Layer *@
+                            <canvas id="@($"{PdfFile.Id}_textannotation")" class="blazorpdf-text__canvas"></canvas>
                         </div>
                         <div>
                             @* Text Layer *@

--- a/Gotho.BlazorPdf/BlazorPdfIcons/TextIcon.razor
+++ b/Gotho.BlazorPdf/BlazorPdfIcons/TextIcon.razor
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="@Color" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-type">
+    <polyline points="4 7 4 4 20 4 20 7"></polyline>
+    <line x1="9" y1="20" x2="15" y2="20"></line>
+    <line x1="12" y1="4" x2="12" y2="20"></line>
+</svg>
+
+@code
+{
+    [Parameter, EditorRequired] public required string Color { get; set; }
+}

--- a/Gotho.BlazorPdf/Config/BlazorPdfLocalizedStrings.cs
+++ b/Gotho.BlazorPdf/Config/BlazorPdfLocalizedStrings.cs
@@ -25,6 +25,12 @@ public class BlazorPdfLocalizedStrings
     public string DrawingThickness { get; set; } = "Thickness";
     public string DrawingUndo { get; set; } = "Undo";
     public string DrawingClear { get; set; } = "Clear";
+    public string Text { get; set; } = "Text";
+    public string TextTools { get; set; } = "Text Tools";
+    public string TextColor { get; set; } = "Color";
+    public string TextFont { get; set; } = "Font";
+    public string TextUndo { get; set; } = "Undo";
+    public string TextClear { get; set; } = "Clear";
     public string PasswordRequired { get; set; } = "Password Required";
     public string PasswordHint { get; set; } = "Please enter the password for the PDF document";
 }

--- a/Gotho.BlazorPdf/Pdf/Pdf.cs
+++ b/Gotho.BlazorPdf/Pdf/Pdf.cs
@@ -25,6 +25,7 @@ public class Pdf
     public Zoom Zooming { get; init; } = new();
     public Page Paging { get; init; } = new();
     public DrawLayer DrawLayer { get; set; } = new();
+    public TextLayer TextLayer { get; set; } = new();
 
     public string? Password { get; private set; } = null;
 
@@ -61,6 +62,9 @@ public class Pdf
             DrawLayerEnabled = DrawLayer.Enabled,
             PenColor = DrawLayer.PenColor,
             PenThickness = DrawLayer.PenThickness,
+            TextLayerEnabled = TextLayer.Enabled,
+            TextColor = TextLayer.TextColor,
+            TextFont = TextLayer.Font,
         };
     }
 }

--- a/Gotho.BlazorPdf/Pdf/PdfState.cs
+++ b/Gotho.BlazorPdf/Pdf/PdfState.cs
@@ -15,4 +15,7 @@ internal class PdfState
     public required bool DrawLayerEnabled { get; set; }
     public required string PenColor { get; set; }
     public required int PenThickness { get; set; }
+    public required bool TextLayerEnabled { get; set; }
+    public required string TextColor { get; set; }
+    public required string TextFont { get; set; }
 }

--- a/Gotho.BlazorPdf/Pdf/TextLayer.cs
+++ b/Gotho.BlazorPdf/Pdf/TextLayer.cs
@@ -1,0 +1,24 @@
+namespace Gotho.BlazorPdf.Pdf;
+
+public class TextLayer
+{
+    public bool Enabled { get; private set; } = false;
+
+    public string TextColor { get; private set; } = "#000000";
+    public string Font { get; private set; } = "16px sans-serif";
+
+    public void Toggle()
+    {
+        Enabled = !Enabled;
+    }
+
+    public void UpdateColor(string color)
+    {
+        TextColor = color;
+    }
+
+    public void UpdateFont(string font)
+    {
+        Font = font;
+    }
+}

--- a/Gotho.BlazorPdf/PdfInterop.cs
+++ b/Gotho.BlazorPdf/PdfInterop.cs
@@ -42,6 +42,18 @@ internal class PdfInterop(IJSRuntime jsRuntime) : IAsyncDisposable
         await module.InvokeVoidAsync("clearStrokesForPage", objRef, pdf.Id);
     }
 
+    public async Task UndoLastTextAsync(object objRef, Pdf pdf)
+    {
+        var module = await js.Value;
+        await module.InvokeVoidAsync("undoLastText", objRef, pdf.Id);
+    }
+
+    public async Task ClearTextForPageAsync(object objRef, Pdf pdf)
+    {
+        var module = await js.Value;
+        await module.InvokeVoidAsync("clearTextForPage", objRef, pdf.Id);
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (js.IsValueCreated)

--- a/Gotho.BlazorPdf/PdfViewer.razor
+++ b/Gotho.BlazorPdf/PdfViewer.razor
@@ -169,6 +169,14 @@
                                 <span
                                     class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.Draw</span>
                             </button>
+                            <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
+                                    @onclick="ToggleTextAsync">
+                                <span class="blazorpdf-toolbar__menu-menu-item-icon">
+                                    <TextIcon Color="@Colors.Icon"/>
+                                </span>
+                                <span
+                                    class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.Text</span>
+                            </button>
                         }
                     </div>
                 </div>
@@ -246,6 +254,30 @@
                     </div>
                 </div>
             }
+            @if (PdfFile.TextLayer.Enabled)
+            {
+                <div class="blazorpdf-text__container">
+                    <div class="blazorpdf-text__close">
+                        <button type="button" @onclick="@ToggleTextAsync">
+                            <CloseIcon Color="@Colors.Icon"/>
+                        </button>
+                    </div>
+                    <span>@LocalizedStrings.TextTools</span>
+                    <div class="blazorpdf-text__input-group">
+                        <label for="@($"{PdfFile.Id}_text_color")">@LocalizedStrings.TextColor</label>
+                        <input id="@($"{PdfFile.Id}_text_color")" type="color" @onchange="TextColorChanged" value="@PdfFile.TextLayer.TextColor"/>
+                    </div>
+                    <div class="blazorpdf-text__input-group">
+                        <label for="@($"{PdfFile.Id}_text_font")">@LocalizedStrings.TextFont</label>
+                        <input id="@($"{PdfFile.Id}_text_font")" type="text" @onchange="FontChanged" value="@PdfFile.TextLayer.Font"/>
+                    </div>
+                    <hr class="blazorpdf-text__hr"/>
+                    <div class="blazorpdf-text__button-group">
+                        <button type="button" @onclick="UndoLastTextAsync">@LocalizedStrings.TextUndo</button>
+                        <button type="button" @onclick="ClearAllPageTextAsync">@LocalizedStrings.TextClear</button>
+                    </div>
+                </div>
+            }
         </div>
 
 
@@ -268,6 +300,10 @@
                     <div>
                         @* Drawing Layer *@
                         <canvas id="@($"{PdfFile.Id}_drawing")" class="blazorpdf-drawing__canvas"></canvas>
+                    </div>
+                    <div>
+                        @* Text Annotation Layer *@
+                        <canvas id="@($"{PdfFile.Id}_textannotation")" class="blazorpdf-text__canvas"></canvas>
                     </div>
                     <div>
                         @* Text Layer *@
@@ -313,5 +349,15 @@
             thickness = parsedInt;
 
         await UpdatePenThickness(thickness);
+    }
+
+    private async Task TextColorChanged(ChangeEventArgs obj)
+    {
+        await UpdateTextColorAsync(obj.Value as string ?? "#000000");
+    }
+
+    private async Task FontChanged(ChangeEventArgs obj)
+    {
+        await UpdateTextFontAsync(obj.Value as string ?? "16px sans-serif");
     }
 }

--- a/Gotho.BlazorPdf/PdfViewer.razor.cs
+++ b/Gotho.BlazorPdf/PdfViewer.razor.cs
@@ -295,6 +295,38 @@ public partial class PdfViewer : ComponentBase
     }
 
     #endregion
+
+    #region Text
+
+    protected async Task ToggleTextAsync()
+    {
+        PdfFile.TextLayer.Toggle();
+        await PdfInterop.UpdateAsync(ObjectReference!, PdfFile);
+    }
+
+    protected async Task UpdateTextColorAsync(string color)
+    {
+        PdfFile.TextLayer.UpdateColor(color);
+        await PdfInterop.UpdateAsync(ObjectReference!, PdfFile);
+    }
+
+    protected async Task UpdateTextFontAsync(string font)
+    {
+        PdfFile.TextLayer.UpdateFont(font);
+        await PdfInterop.UpdateAsync(ObjectReference!, PdfFile);
+    }
+
+    protected async Task UndoLastTextAsync()
+    {
+        await PdfInterop.UndoLastTextAsync(ObjectReference!, PdfFile);
+    }
+
+    protected async Task ClearAllPageTextAsync()
+    {
+        await PdfInterop.ClearTextForPageAsync(ObjectReference!, PdfFile);
+    }
+
+    #endregion
     
     protected async Task DownloadDocumentAsync()
     {

--- a/Gotho.BlazorPdf/Ts/Pdf.ts
+++ b/Gotho.BlazorPdf/Ts/Pdf.ts
@@ -1,6 +1,7 @@
 import {PDFDocumentProxy, getFilenameFromUrl} from "pdfjs-dist"
 import {PdfState} from "./PdfState";
 import {PdfDrawLayer} from "./PdfDrawLayer";
+import {PdfTextLayer} from "./PdfTextLayer";
 
 const pdfInstances = {}
 
@@ -23,6 +24,7 @@ export class Pdf {
     public source: string;
     
     public drawLayer: PdfDrawLayer;
+    public textLayer: PdfTextLayer;
 
     constructor(id: string, scale: number, rotation: number, url: string, singlePageMode: boolean, source: string, password: string = null) {
         this.id = id;
@@ -40,6 +42,7 @@ export class Pdf {
         this.source = source.toLowerCase();
         this.password = password
         this.drawLayer = new PdfDrawLayer(id);
+        this.textLayer = new PdfTextLayer(id);
 
         pdfInstances[this.id] = this;
     }

--- a/Gotho.BlazorPdf/Ts/PdfState.ts
+++ b/Gotho.BlazorPdf/Ts/PdfState.ts
@@ -10,4 +10,7 @@ export class PdfState {
     public drawLayerEnabled: boolean
     public penColor: string
     public penThickness: number
+    public textLayerEnabled: boolean
+    public textColor: string
+    public textFont: string
 }

--- a/Gotho.BlazorPdf/Ts/PdfTextLayer.ts
+++ b/Gotho.BlazorPdf/Ts/PdfTextLayer.ts
@@ -1,0 +1,154 @@
+interface TextAnnotation {
+    text: string;
+    color: string;
+    font: string;
+    x: number;
+    y: number;
+}
+
+export class PdfTextLayer {
+    public textStore: Record<number, TextAnnotation[]> = {};
+    public canvas: HTMLCanvasElement;
+    public canvasContext: CanvasRenderingContext2D;
+    public enabled: boolean;
+
+    private id: string;
+    private texts: TextAnnotation[] = [];
+    private rotation: number;
+    private textColor: string = "#000000";
+    private textFont: string = "16px sans-serif";
+    private currentPage: number = 1;
+    private boundClick: (e: MouseEvent) => void;
+
+    constructor(id: string) {
+        this.id = id;
+        this.boundClick = this.onClick.bind(this);
+
+        this.canvas = document.getElementById(`${id}_textannotation`) as HTMLCanvasElement;
+        if (this.canvas) {
+            this.canvasContext = this.canvas.getContext("2d");
+            this.canvasContext.fillStyle = this.textColor;
+            this.canvasContext.font = this.textFont;
+            this.canvas.style.display = "none";
+        }
+    }
+
+    public enable() {
+        this.enabled = true;
+        this.canvas.style.removeProperty("display");
+        const textLayer = document.getElementById(`${this.id}_text`);
+        if (textLayer) {
+            textLayer.style.display = "none";
+        }
+        this.canvas.addEventListener("click", this.boundClick);
+    }
+
+    public disable() {
+        this.enabled = false;
+        this.canvas.style.display = "none";
+        const textLayer = document.getElementById(`${this.id}_text`);
+        if (textLayer) {
+            textLayer.style.removeProperty("display");
+        }
+        this.canvas.removeEventListener("click", this.boundClick);
+    }
+
+    public updateTextSettings(color: string, font: string) {
+        this.textColor = color;
+        this.textFont = font;
+        if (this.canvasContext) {
+            this.canvasContext.fillStyle = color;
+            this.canvasContext.font = font;
+        }
+    }
+
+    public updateCanvas(pageNumber: number,
+                        height: number,
+                        width: number,
+                        offsetLeft: number,
+                        offsetTop: number,
+                        rotation: number) {
+        this.rotation = ((rotation % 360) + 360) % 360;
+        this.textStore[this.currentPage] = [...this.texts];
+        this.currentPage = pageNumber;
+        this.texts = this.textStore[pageNumber] ? [...this.textStore[pageNumber]] : [];
+        if (this.canvas) {
+            this.canvas.width = width;
+            this.canvas.height = height;
+            this.canvas.style.width = width + 'px';
+            this.canvas.style.height = height + 'px';
+            this.canvas.style.left = offsetLeft + 'px';
+            this.canvas.style.top = offsetTop + 'px';
+            this.redrawTexts();
+        }
+    }
+
+    public undoLastText() {
+        if (this.texts.length > 0) {
+            this.texts.pop();
+            this.redrawTexts();
+        }
+    }
+
+    public clearPageText() {
+        this.texts = [];
+        this.textStore[this.currentPage] = [];
+        this.redrawTexts();
+    }
+
+    public getAllText(): Record<number, TextAnnotation[]> {
+        this.textStore[this.currentPage] = [...this.texts];
+        return this.textStore;
+    }
+
+    public loadAllText(data: Record<number, TextAnnotation[]>) {
+        this.textStore = data;
+        this.texts = this.textStore[this.currentPage] ?? [];
+        this.redrawTexts();
+    }
+
+    private onClick(e: MouseEvent) {
+        if (!this.canvasContext || !this.canvas) return;
+        const value = prompt("Enter text");
+        if (!value) return;
+        const [x, y] = this.getNormalizedMousePos(this.canvas, e);
+        const [rx, ry] = this.rotatePoint(x, y, this.rotation);
+        this.canvasContext.fillStyle = this.textColor;
+        this.canvasContext.font = this.textFont;
+        this.canvasContext.fillText(value, rx * this.canvas.width, ry * this.canvas.height);
+        this.texts.push({text: value, color: this.textColor, font: this.textFont, x, y});
+    }
+
+    private redrawTexts() {
+        if (!this.canvasContext || !this.canvas) return;
+        this.canvasContext.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        const w = this.canvas.width;
+        const h = this.canvas.height;
+        for (const t of this.texts) {
+            const [rx, ry] = this.rotatePoint(t.x, t.y, this.rotation);
+            this.canvasContext.fillStyle = t.color;
+            this.canvasContext.font = t.font;
+            this.canvasContext.fillText(t.text, rx * w, ry * h);
+        }
+    }
+
+    private getNormalizedMousePos(canvas: HTMLCanvasElement, evt: MouseEvent): [number, number] {
+        const rect = canvas.getBoundingClientRect();
+        const x = (evt.clientX - rect.left) / canvas.width;
+        const y = (evt.clientY - rect.top) / canvas.height;
+        return [x, y];
+    }
+
+    private rotatePoint(x: number, y: number, rotation: number): [number, number] {
+        switch (rotation) {
+            case 90:
+                return [1 - y, x];
+            case 180:
+                return [1 - x, 1 - y];
+            case 270:
+                return [y, 1 - x];
+            default:
+                return [x, y];
+        }
+    }
+}

--- a/Gotho.BlazorPdf/Ts/PdfViewer.ts
+++ b/Gotho.BlazorPdf/Ts/PdfViewer.ts
@@ -34,6 +34,14 @@ export function initPdfViewer(dotnetReference: any, pdfDto: PdfState, singlePage
 
     if (pdfDto.url) {
         const pdf = new Pdf(pdfDto.id, pdfDto.scale, pdfDto.orientation, pdfDto.url, singlePageMode, pdfDto.source, pdfDto.password)
+        pdf.drawLayer.updatePenSettings(pdfDto.penColor, pdfDto.penThickness);
+        pdf.textLayer.updateTextSettings(pdfDto.textColor, pdfDto.textFont);
+        if (pdfDto.drawLayerEnabled && singlePageMode) {
+            pdf.drawLayer.enable();
+        }
+        if (pdfDto.textLayerEnabled && singlePageMode) {
+            pdf.textLayer.enable();
+        }
 
         pdfjs.getDocument(getDocumentInit(pdfDto)).promise.then(doc => {
             pdf.setDocument(doc)
@@ -55,12 +63,21 @@ export function updatePdf(dotnetReference: any, pdfDto: PdfState) {
     const previousPage = pdf.currentPage;
     pdf.updatePdf(pdfDto)
     pdf.drawLayer.updatePenSettings(pdfDto.penColor, pdfDto.penThickness);
-    
+    pdf.textLayer.updateTextSettings(pdfDto.textColor, pdfDto.textFont);
+
     if (pdf.drawLayer.enabled !== pdfDto.drawLayerEnabled && pdf.singlePageMode) {
         if (pdfDto.drawLayerEnabled) {
             pdf.drawLayer.enable();
         } else {
             pdf.drawLayer.disable();
+        }
+    }
+
+    if (pdf.textLayer.enabled !== pdfDto.textLayerEnabled && pdf.singlePageMode) {
+        if (pdfDto.textLayerEnabled) {
+            pdf.textLayer.enable();
+        } else {
+            pdf.textLayer.disable();
         }
     }
 
@@ -119,33 +136,40 @@ export async function printDocument(dotnetReference: any, id: string) {
         mergedContext.drawImage(pdfImage, 0, 0);
 
         // Draw annotation layer
+        const annotationCanvas = document.createElement('canvas');
+        annotationCanvas.width = mergedCanvas.width;
+        annotationCanvas.height = mergedCanvas.height;
+        const annotationCtx = annotationCanvas.getContext('2d');
+
         const drawingLayer = pdf.drawLayer;
         const pageStrokes = drawingLayer.drawingStore[pageNum] || [];
+        for (const stroke of pageStrokes) {
+            annotationCtx.beginPath();
+            annotationCtx.strokeStyle = stroke.color;
+            annotationCtx.lineWidth = stroke.thickness;
 
-        if (pageStrokes.length > 0) {
-            const annotationCanvas = document.createElement('canvas');
-            annotationCanvas.width = mergedCanvas.width;
-            annotationCanvas.height = mergedCanvas.height;
-            const annotationCtx = annotationCanvas.getContext('2d');
+            stroke.points.forEach((p, i) => {
+                const x = p.x * annotationCanvas.width;
+                const y = p.y * annotationCanvas.height;
+                if (i === 0) {
+                    annotationCtx.moveTo(x, y);
+                } else {
+                    annotationCtx.lineTo(x, y);
+                }
+            });
 
-            for (const stroke of pageStrokes) {
-                annotationCtx.beginPath();
-                annotationCtx.strokeStyle = stroke.color;
-                annotationCtx.lineWidth = stroke.thickness;
+            annotationCtx.stroke();
+        }
 
-                stroke.points.forEach((p, i) => {
-                    const x = p.x * annotationCanvas.width;
-                    const y = p.y * annotationCanvas.height;
-                    if (i === 0) {
-                        annotationCtx.moveTo(x, y);
-                    } else {
-                        annotationCtx.lineTo(x, y);
-                    }
-                });
+        const textLayer = pdf.textLayer;
+        const pageTexts = textLayer.textStore[pageNum] || [];
+        for (const t of pageTexts) {
+            annotationCtx.fillStyle = t.color;
+            annotationCtx.font = t.font;
+            annotationCtx.fillText(t.text, t.x * annotationCanvas.width, t.y * annotationCanvas.height);
+        }
 
-                annotationCtx.stroke();
-            }
-
+        if (pageStrokes.length > 0 || pageTexts.length > 0) {
             mergedContext.drawImage(annotationCanvas, 0, 0);
         }
 
@@ -204,6 +228,16 @@ export function undoLastStroke(dotnetReference: any, id: string) {
 export function clearStrokesForPage(dotnetReference: any, id: string) {
     const pdf = Pdf.getPdf(id);
     pdf.drawLayer.clearPageStrokes();
+}
+
+export function undoLastText(dotnetReference: any, id: string) {
+    const pdf = Pdf.getPdf(id);
+    pdf.textLayer.undoLastText();
+}
+
+export function clearTextForPage(dotnetReference: any, id: string) {
+    const pdf = Pdf.getPdf(id);
+    pdf.textLayer.clearPageText();
 }
 
 function scrollToPage(id: string, pageNumber: number) {
@@ -268,6 +302,7 @@ function renderPdf(pdf: Pdf) {
 
             // Update draw layer
             pdf.drawLayer.updateCanvas(pdf.currentPage, viewport.height, viewport.width, pdf.canvas.offsetLeft, pdf.canvas.offsetTop, pdf.rotation);
+            pdf.textLayer.updateCanvas(pdf.currentPage, viewport.height, viewport.width, pdf.canvas.offsetLeft, pdf.canvas.offsetTop, pdf.rotation);
         })
     } else {
         const container = document.getElementById(pdf.id);

--- a/Gotho.BlazorPdf/wwwroot/blazorpdf.css
+++ b/Gotho.BlazorPdf/wwwroot/blazorpdf.css
@@ -5,6 +5,7 @@
 @import url("blazorpdf_icon.css");
 @import url("blazorpdf_loader.css");
 @import url("blazorpdf_drawing.css");
+@import url("blazorpdf_text.css");
 
 @media (max-width: 768px) {
     .blazorpdf__hide-on-mobile {

--- a/Gotho.BlazorPdf/wwwroot/blazorpdf_text.css
+++ b/Gotho.BlazorPdf/wwwroot/blazorpdf_text.css
@@ -1,0 +1,63 @@
+.blazorpdf-text__canvas {
+    position: absolute;
+}
+
+.blazorpdf-text__container {
+    position: absolute;
+    right: 25px;
+    bottom: 25px;
+    min-width: 250px;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    text-align: center;
+    gap: 15px;
+    background-color: rgba(232, 231, 234, 1);
+    border-radius: 15px;
+    padding: 25px;
+    z-index: 999;
+}
+
+.blazorpdf-text__close {
+    position: absolute;
+    right: 5px;
+    top: 5px;
+}
+
+.blazorpdf-text__close button{
+    background-color: transparent;
+    border: none;
+    outline: none;
+}
+
+.blazorpdf-text__close button:hover {
+    cursor: pointer;
+}
+
+.blazorpdf-text__input-group {
+    display: flex;
+    flex-wrap: nowrap;
+}
+
+.blazorpdf-text__input-group label{
+    width: 50%;
+    color: black;
+}
+
+.blazorpdf-text__input-group input{
+    width: 50%;
+}
+
+.blazorpdf-text__hr {
+    width: 100%;
+}
+
+.blazorpdf-text__button-group {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+}
+
+.blazorpdf-text__button-group button {
+    width: 100%;
+}


### PR DESCRIPTION
## Summary
- add configurable text annotation layer alongside drawing tools
- support font and color selection for text annotations
- integrate text annotations into MudBlazor viewer and asset pipeline

## Testing
- `npm run ts`
- `npm run ts-min`
- `npm run css`
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b593bedd088329b638fa5b005cb150